### PR TITLE
Issue Fixing::Zooming In Browser && Eslint React Exhaustive Deep Chec…

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -5,6 +5,10 @@ const List = () => {
   const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
+    function handleScroll() {
+      if (Math.ceil(window.innerHeight + document.documentElement.scrollTop) !== document.documentElement.offsetHeight || isFetching) return;
+      setIsFetching(true);
+    }
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
@@ -13,11 +17,6 @@ const List = () => {
     if (!isFetching) return;
     fetchMoreListItems();
   }, [isFetching]);
-
-  function handleScroll() {
-    if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight || isFetching) return;
-    setIsFetching(true);
-  }
 
   function fetchMoreListItems() {
     setTimeout(() => {

--- a/src/useInfiniteScroll.js
+++ b/src/useInfiniteScroll.js
@@ -4,6 +4,10 @@ const useInfiniteScroll = (callback) => {
   const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
+    function handleScroll() {
+      if (Math.ceil(window.innerHeight + document.documentElement.scrollTop) !== document.documentElement.offsetHeight || isFetching) return;
+      setIsFetching(true);
+    }
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
@@ -12,11 +16,6 @@ const useInfiniteScroll = (callback) => {
     if (!isFetching) return;
     callback();
   }, [isFetching]);
-
-  function handleScroll() {
-    if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight || isFetching) return;
-    setIsFetching(true);
-  }
 
   return [isFetching, setIsFetching];
 };


### PR DESCRIPTION
When we zoom in chrome and many other browsers, the height comes in decimal points, to fix this issue, I wrapped it in Math.ceil function and to avoid React Exhaustive Deep Check, I moved the handleScroll function inside useEffect.